### PR TITLE
Disable the global external data checker

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "disable-external-data-checker": true
+}


### PR DESCRIPTION
We need a custom workflow to check for external updates because the project contains an embedded `Cargo.lock` file that gets processed into the `flathub-vpn-crates.json` file. Therefore we should disable flathub's global external data checker.