### PR TITLE
Fix tag pattern grouping for release candidates

### DIFF
--- a/org.mozilla.vpn.yml
+++ b/org.mozilla.vpn.yml
@@ -64,7 +64,7 @@ modules:
         commit: a4a065ccb69376014f3e03f4134a0354c9d18848
         x-checker-data:
           type: git
-          tag-pattern: ^v([\d.]+)-rc([\d]+)$
+          tag-pattern: ^v([\d.]+-rc\d+)$
           is-main-source: true
 
       - type: file


### PR DESCRIPTION
The x-data-checker requires that only one regex group is present in the tag.